### PR TITLE
Arregla exportación a Markdown y detección de patrones para tests

### DIFF
--- a/backend/app/core/patterns/pattern_detector.py
+++ b/backend/app/core/patterns/pattern_detector.py
@@ -60,6 +60,11 @@ class PatternDetectionResult:
         return len(self.all_patterns)
 
     @property
+    def high_confidence_count(self) -> int:
+        """Número de patrones con alta confianza (basado en confident_patterns)"""
+        return len(self.confident_patterns)
+
+    @property
     def primary_pattern_name(self) -> Optional[str]:
         """Nombre del patrón primario"""
         return self.primary_pattern.pattern.pattern_name if self.primary_pattern else None

--- a/backend/app/infrastructure/export/markdown_exporter.py
+++ b/backend/app/infrastructure/export/markdown_exporter.py
@@ -6,6 +6,7 @@ ideal para documentación, GitHub, y sitios estáticos.
 """
 
 import time
+import json
 from typing import List, Dict, Any
 
 from app.infrastructure.export.base_exporter import (
@@ -56,6 +57,30 @@ class MarkdownExporter(BaseExporter):
             # Generar contenido Markdown
             sections = []
             
+            # Normalizar visualizaciones y recurrencias (objetos -> dict/str)
+            try:
+                data.visualizations = self.extract_visualization_data(data.visualizations or {})
+            except Exception:
+                data.visualizations = data.visualizations or {}
+
+            # Asegurar que las recurrencias temporales/espaciales sean strings o dicts
+            try:
+                if getattr(data.analysis, "temporal_recurrence", None):
+                    tr = data.analysis.temporal_recurrence
+                    if hasattr(tr, "to_dict"):
+                        data.analysis.temporal_recurrence = tr.to_dict()
+                    elif not isinstance(tr, (str, dict)):
+                        data.analysis.temporal_recurrence = str(tr)
+                if getattr(data.analysis, "spatial_recurrence", None):
+                    sr = data.analysis.spatial_recurrence
+                    if hasattr(sr, "to_dict"):
+                        data.analysis.spatial_recurrence = sr.to_dict()
+                    elif not isinstance(sr, (str, dict)):
+                        data.analysis.spatial_recurrence = str(sr)
+            except Exception:
+                # No bloquear la exportación por problemas de serialización
+                pass
+
             sections.append(self._generate_header(data))
             sections.append(self._generate_metadata(data))
             
@@ -184,12 +209,29 @@ class MarkdownExporter(BaseExporter):
         
         # Ecuación de recurrencia temporal
         if data.analysis.temporal_recurrence:
+            temporal = data.analysis.temporal_recurrence
+
+            # Normalizar a texto: puede ser un string o un objeto TemporalComplexityResult
+            if isinstance(temporal, str):
+                recurrence_text = temporal
+            elif hasattr(temporal, "recurrence_equation") and getattr(temporal, "recurrence_equation"):
+                # Usar la ecuación si está disponible
+                recurrence_text = getattr(temporal.recurrence_equation, "equation", str(temporal))
+            elif hasattr(temporal, "to_dict"):
+                # Volcar a JSON legible
+                try:
+                    recurrence_text = json.dumps(temporal.to_dict(), ensure_ascii=False, indent=2)
+                except Exception:
+                    recurrence_text = str(temporal)
+            else:
+                recurrence_text = str(temporal)
+
             lines.extend([
                 "",
                 "#### Ecuación de Recurrencia",
                 "",
-                f"```",
-                data.analysis.temporal_recurrence,
+                "```",
+                recurrence_text,
                 "```",
             ])
         
@@ -203,12 +245,22 @@ class MarkdownExporter(BaseExporter):
             ])
             
             if data.analysis.spatial_recurrence:
+                # Normalizar la recurrencia espacial a texto legible
+                sr = data.analysis.spatial_recurrence
+                if isinstance(sr, dict):
+                    try:
+                        sr_text = json.dumps(sr, ensure_ascii=False, indent=2)
+                    except Exception:
+                        sr_text = str(sr)
+                else:
+                    sr_text = str(sr)
+
                 lines.extend([
                     "",
                     "#### Ecuación de Recurrencia Espacial",
                     "",
-                    f"```",
-                    data.analysis.spatial_recurrence,
+                    "```",
+                    sr_text,
                     "```",
                 ])
         
@@ -282,34 +334,46 @@ class MarkdownExporter(BaseExporter):
 
         line_data = data.analysis.line_by_line
 
-        # CORRECCIÓN: Verificar el tipo de line_by_line
+        # Manejar diferentes estructuras de datos
         if isinstance(line_data, dict):
-            # Ordenar por número de línea
-            sorted_items = sorted(line_data.items(), key=lambda x: int(x[0]) if isinstance(x[0], (int, str)) and str(x[0]).isdigit() else 0)
+            sorted_items = sorted(
+                line_data.items(), 
+                key=lambda x: int(x[0]) if str(x[0]).isdigit() else 0
+            )
 
             for line_num, info in sorted_items:
-                # Verificar que info sea un dict
                 if not isinstance(info, dict):
                     continue
 
-                code = info.get("code", "").strip()[:50]  # Limitar longitud
+                code = str(info.get("code", "")).strip()[:50]
+
+                # IMPORTANTE: Convertir a string todo lo que pueda ser objeto
                 complexity = info.get("complexity", "O(1)")
+                if hasattr(complexity, '__dict__') or not isinstance(complexity, str):
+                    complexity = str(complexity) if complexity else "O(1)"
+
                 executions = info.get("executions", "1")
+                if hasattr(executions, '__dict__') or not isinstance(executions, (str, int, float)):
+                    executions = str(executions) if executions else "1"
 
-                # Escapar caracteres especiales en markdown
                 code = code.replace("|", "\\|")
-
                 lines.append(f"| {line_num} | `{code}` | `{complexity}` | {executions} |")
+
         elif isinstance(line_data, list):
-            # Si es una lista, iterar directamente
             for i, info in enumerate(line_data, 1):
                 if not isinstance(info, dict):
                     continue
 
                 line_num = info.get("line", i)
-                code = info.get("code", "").strip()[:50]
+                code = str(info.get("code", "")).strip()[:50]
+
                 complexity = info.get("complexity", "O(1)")
+                if hasattr(complexity, '__dict__') or not isinstance(complexity, str):
+                    complexity = str(complexity) if complexity else "O(1)"
+
                 executions = info.get("executions", "1")
+                if hasattr(executions, '__dict__') or not isinstance(executions, (str, int, float)):
+                    executions = str(executions) if executions else "1"
 
                 code = code.replace("|", "\\|")
                 lines.append(f"| {line_num} | `{code}` | `{complexity}` | {executions} |")

--- a/backend/app/schemas/pattern.py
+++ b/backend/app/schemas/pattern.py
@@ -7,7 +7,7 @@ Schemas Pydantic para representar patrones algorítmicos detectados.
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.schemas.common import ConfidenceLevelEnum
 
@@ -36,7 +36,7 @@ class PatternIndicator(BaseModel):
     weight: float = Field(..., ge=0.0, le=1.0, description="Peso en el cálculo de confianza")
     evidence: Optional[str] = Field(None, description="Evidencia encontrada en el código")
     location: Optional[str] = Field(None, description="Ubicación en el AST")
-    
+
     class Config:
         json_schema_extra = {
             "example": {
@@ -180,15 +180,6 @@ class PatternDetectionResult(BaseModel):
         description="Número de patrones con alta confianza"
     )
 
-    from pydantic import model_validator
-
-    @model_validator(mode='after')  
-    def compute_high_confidence_count(self):
-        """Calcula automáticamente high_confidence_count si no se provee"""
-        if self.high_confidence_count == 0 and self.confident_patterns:
-            self.high_confidence_count = len(self.confident_patterns)
-        return self
-
     statistics: Optional["PatternStatistics"] = Field(
         None,
         description="Estadísticas de detección"
@@ -198,6 +189,14 @@ class PatternDetectionResult(BaseModel):
         default_factory=dict,
         description="Metadata del análisis"
     )
+    
+    # model_validator FUERA de los campos, como método de clase
+    @model_validator(mode='after')
+    def compute_high_confidence_count(self):
+        """Calcula automáticamente high_confidence_count si no se provee"""
+        if self.high_confidence_count == 0 and self.confident_patterns:
+            self.high_confidence_count = len(self.confident_patterns)
+        return self
     
     @property
     def has_patterns(self) -> bool:
@@ -245,6 +244,7 @@ class PatternDetectionResult(BaseModel):
                 ],
                 "summary": "Patrón principal: Divide y Vencerás (confianza: 95%). También detectado: Recursión (88%).",
                 "pattern_count": 2,
+                "high_confidence_count": 1,
                 "metadata": {
                     "analysis_time_ms": 45.2,
                     "detectors_used": 12
@@ -255,32 +255,31 @@ class PatternDetectionResult(BaseModel):
 # Pattern Statistics
 class PatternStatistics(BaseModel):
     """Estadísticas de detección de patrones"""
-    total_patterns_analyzed: int = Field(..., ge=0, description="Total de patrones evaluados")
-    patterns_detected: int = Field(..., ge=0, description="Patrones detectados")
-    high_confidence_count: int = Field(..., ge=0, description="Patrones con alta confianza")
+    total_patterns_detected: int = Field(..., ge=0, description="Total de patrones detectados")
+    high_confidence_patterns: int = Field(..., ge=0, description="Patrones con alta confianza")
+    medium_confidence_patterns: int = Field(..., ge=0, description="Patrones con confianza media")
+    low_confidence_patterns: int = Field(..., ge=0, description="Patrones con confianza baja")
     
-    average_confidence: float = Field(..., ge=0.0, le=1.0, description="Confianza promedio")
-    max_confidence: float = Field(..., ge=0.0, le=1.0, description="Confianza máxima")
-    min_confidence: float = Field(..., ge=0.0, le=1.0, description="Confianza mínima")
-    
-    pattern_distribution: Dict[str, int] = Field(
-        default_factory=dict,
-        description="Distribución por tipo de patrón"
+    pattern_types_found: List[PatternType] = Field(
+        default_factory=list,
+        description="Tipos de patrones encontrados"
     )
+    most_confident_pattern: Optional[str] = Field(
+        None,
+        description="Patrón con mayor confianza"
+    )
+    average_confidence: float = Field(..., ge=0.0, le=1.0, description="Confianza promedio")
     
     class Config:
         json_schema_extra = {
             "example": {
-                "total_patterns_analyzed": 12,
-                "patterns_detected": 2,
-                "high_confidence_count": 1,
-                "average_confidence": 0.65,
-                "max_confidence": 0.92,
-                "min_confidence": 0.38,
-                "pattern_distribution": {
-                    "divide_and_conquer": 1,
-                    "recursive": 1
-                }
+                "total_patterns_detected": 12,
+                "high_confidence_patterns": 2,
+                "medium_confidence_patterns": 5,
+                "low_confidence_patterns": 5,
+                "pattern_types_found": ["divide_and_conquer", "recursive"],
+                "most_confident_pattern": "Divide y Vencerás",
+                "average_confidence": 0.65
             }
         }
 


### PR DESCRIPTION
Corrige formateo en markdown_exporter y ajusta la lógica de detección de patrones que rompía los endpoints; los tests test_export_to_markdown y test_dettect_patterns pasan ahora