### PR TITLE
feat(llm): agregar Circuit Breaker y mejorar evaluación/ruteo de LLMs

### DIFF
--- a/backend/app/infrastructure/llm/llm_circuit_breaker.py
+++ b/backend/app/infrastructure/llm/llm_circuit_breaker.py
@@ -1,0 +1,192 @@
+"""
+CircuitBreaker — Detecta LLMs degradados y evita llamadas en cascada.
+
+Patrón Circuit Breaker clásico con tres estados:
+    CLOSED   → llamadas permitidas (operación normal)
+    OPEN     → llamadas bloqueadas (demasiados fallos recientes)
+    HALF_OPEN → probando si el LLM se recuperó (una llamada de prueba)
+
+Transiciones:
+    CLOSED  → OPEN      cuando failures >= threshold en la ventana
+    OPEN    → HALF_OPEN cuando pasa recovery_timeout segundos
+    HALF_OPEN → CLOSED  cuando la llamada de prueba tiene éxito
+    HALF_OPEN → OPEN    cuando la llamada de prueba falla
+
+Diseño:
+    - Sin dependencias externas (solo stdlib)
+    - Thread-safe para uso en contextos async (asyncio es single-threaded)
+    - Serializable a dict para métricas Prometheus
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+class CircuitState(str, Enum):
+    CLOSED    = "closed"
+    OPEN      = "open"
+    HALF_OPEN = "half_open"
+
+@dataclass
+class CircuitBreakerMetrics:
+    """Snapshot del estado del circuit breaker para métricas."""
+    name: str
+    state: CircuitState
+    failure_count: int
+    last_failure_time: Optional[float]
+    seconds_until_retry: float
+
+    def to_dict(self) -> dict:
+        return {
+            "name":                self.name,
+            "state":               self.state.value,
+            "failure_count":       self.failure_count,
+            "last_failure_time":   self.last_failure_time,
+            "seconds_until_retry": round(self.seconds_until_retry, 1),
+        }
+
+class CircuitBreaker:
+    """
+    Circuit breaker para un LLM específico.
+
+    Un CircuitBreaker por LLM — el LLMRouter mantiene uno por adaptador.
+
+    Args:
+        name:              Nombre del LLM (para logs y métricas).
+        failure_threshold: Fallos consecutivos para abrir el circuito.
+        recovery_timeout:  Segundos antes de intentar HALF_OPEN.
+        window_size:       Tamaño de la ventana deslizante de fallos.
+
+    Example:
+        >>> cb = CircuitBreaker("ollama", failure_threshold=3)
+        >>> if cb.is_open:
+        ...     raise RuntimeError("LLM no disponible")
+        >>> try:
+        ...     result = await llm.generate(prompt)
+        ...     cb.record_success()
+        ... except Exception:
+        ...     cb.record_failure()
+        ...     raise
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 60.0,
+        window_size: int = 10,
+    ) -> None:
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+
+        self._state: CircuitState = CircuitState.CLOSED
+        self._failures: deque[float] = deque(maxlen=window_size)
+        self._last_failure_time: float = 0.0
+
+    #  Estado público                                                     
+    @property
+    def is_open(self) -> bool:
+        """
+        True si las llamadas deben ser bloqueadas.
+
+        También maneja la transición OPEN → HALF_OPEN cuando
+        ha pasado suficiente tiempo.
+        """
+        if self._state == CircuitState.OPEN:
+            elapsed = time.time() - self._last_failure_time
+            if elapsed >= self.recovery_timeout:
+                self._state = CircuitState.HALF_OPEN
+                return False
+            return True
+        return False
+
+    @property
+    def state(self) -> CircuitState:
+        """Estado actual (evalúa transición OPEN→HALF_OPEN si aplica)."""
+        _ = self.is_open
+        return self._state
+
+    @property
+    def is_half_open(self) -> bool:
+        """True si estamos en modo de prueba (una llamada permitida)."""
+        return self.state == CircuitState.HALF_OPEN
+
+    #  Registro de resultados                                             
+    def record_success(self) -> None:
+        """
+        Registra una llamada exitosa.
+
+        Si estábamos HALF_OPEN, cierra el circuito (LLM se recuperó).
+        Si estábamos CLOSED, limpia el historial de fallos.
+        """
+        was_half_open = self._state == CircuitState.HALF_OPEN
+        self._failures.clear()
+        self._state = CircuitState.CLOSED
+        if was_half_open:
+            from app.utils.logger import setup_logger
+            setup_logger(__name__).info(
+                f"CircuitBreaker '{self.name}': HALF_OPEN → CLOSED (recuperado)"
+            )
+
+    def record_failure(self) -> None:
+        """
+        Registra un fallo.
+
+        Si los fallos superan el threshold, abre el circuito.
+        Si estábamos HALF_OPEN, vuelve a OPEN.
+        """
+        now = time.time()
+        self._failures.append(now)
+        self._last_failure_time = now
+
+        if self._state == CircuitState.HALF_OPEN:
+            self._state = CircuitState.OPEN
+            from app.utils.logger import setup_logger
+            setup_logger(__name__).warning(
+                f"CircuitBreaker '{self.name}': HALF_OPEN → OPEN "
+                f"(fallo en llamada de prueba)"
+            )
+            return
+
+        if len(self._failures) >= self.failure_threshold:
+            if self._state != CircuitState.OPEN:
+                self._state = CircuitState.OPEN
+                from app.utils.logger import setup_logger
+                setup_logger(__name__).warning(
+                    f"CircuitBreaker '{self.name}': CLOSED → OPEN "
+                    f"({len(self._failures)} fallos en ventana)"
+                )
+
+    #  Métricas                                                           
+    def get_metrics(self) -> CircuitBreakerMetrics:
+        """Snapshot del estado actual para Prometheus o logging."""
+        retry_in = 0.0
+        if self._state == CircuitState.OPEN:
+            elapsed = time.time() - self._last_failure_time
+            retry_in = max(0.0, self.recovery_timeout - elapsed)
+
+        return CircuitBreakerMetrics(
+            name=self.name,
+            state=self.state,
+            failure_count=len(self._failures),
+            last_failure_time=self._last_failure_time or None,
+            seconds_until_retry=retry_in,
+        )
+
+    def reset(self) -> None:
+        """Resetea el circuit breaker a estado inicial. Solo para tests."""
+        self._state = CircuitState.CLOSED
+        self._failures.clear()
+        self._last_failure_time = 0.0
+
+    def __repr__(self) -> str:
+        return (
+            f"<CircuitBreaker name={self.name!r} "
+            f"state={self.state.value} "
+            f"failures={len(self._failures)}/{self.failure_threshold}>"
+        )

--- a/backend/app/infrastructure/llm/llm_evaluator.py
+++ b/backend/app/infrastructure/llm/llm_evaluator.py
@@ -1,0 +1,178 @@
+"""
+LLMEvaluator — Evalúa calidad de respuesta LLM sin hacer otra llamada.
+
+El score resultante permite al LLMRouter decidir si acepta la respuesta
+del LLM primario o intenta el fallback.
+
+Criterios de evaluación:
+    1. JSON válido cuando se espera JSON (35% del score)
+    2. Campos requeridos presentes (40% del score)
+    3. Latencia aceptable (25% del score)
+    4. Ajuste opcional por confianza que reporta el propio LLM
+
+Diseño:
+    - Sin estado (todos los métodos son pure functions equivalentes)
+    - Sin dependencias externas
+    - Extensible: agregar criterios sin cambiar la interfaz
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+@dataclass
+class EvaluationResult:
+    """Resultado de la evaluación de una respuesta LLM."""
+    score: float                     # 0.0 a 1.0 — score final
+    is_valid_json: bool
+    has_required_fields: bool
+    latency_ms: float
+    confidence_indicator: Optional[float]  # Si el LLM reporta confianza propia
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def is_acceptable(self) -> bool:
+        """True si el score supera 0.6 (umbral por defecto del router)."""
+        return self.score >= 0.6
+
+    def to_dict(self) -> dict:
+        return {
+            "score":               round(self.score, 3),
+            "is_valid_json":       self.is_valid_json,
+            "has_required_fields": self.has_required_fields,
+            "latency_ms":          round(self.latency_ms, 1),
+            "confidence":          self.confidence_indicator,
+            "reasons":             self.reasons,
+        }
+
+class LLMEvaluator:
+    """
+    Evalúa la calidad de respuestas de LLMs.
+
+    Usado por LLMRouter para decidir si aceptar la respuesta
+    del primario o intentar el fallback.
+
+    Example:
+        >>> evaluator = LLMEvaluator()
+        >>> result = evaluator.evaluate(
+        ...     response_content='{"big_o": "O(n^2)", "omega": "Omega(n)"}',
+        ...     required_fields=["big_o", "omega"],
+        ...     latency_ms=450.0,
+        ... )
+        >>> print(result.score)  # 0.95
+        >>> print(result.is_acceptable)  # True
+    """
+
+    def evaluate(
+        self,
+        response_content: str,
+        required_fields: list[str],
+        latency_ms: float,
+        max_acceptable_latency_ms: float = 10_000.0,
+    ) -> EvaluationResult:
+        """
+        Evalúa una respuesta y retorna un score entre 0.0 y 1.0.
+
+        Args:
+            response_content:          Texto de la respuesta del LLM.
+            required_fields:           Campos que deben estar presentes
+                                       (vacío = solo evaluar latencia y JSON).
+            latency_ms:                Tiempo de respuesta en milisegundos.
+            max_acceptable_latency_ms: Latencia máxima tolerable.
+
+        Returns:
+            EvaluationResult con score y detalles.
+        """
+        score = 0.0
+        reasons: list[str] = []
+
+        # Criterio 1: JSON válido (35%) 
+        is_json = False
+        parsed: Optional[dict[str, Any]] = None
+
+        try:
+            parsed = json.loads(response_content.strip())
+            is_json = True
+            score += 0.35
+        except (json.JSONDecodeError, ValueError):
+            reasons.append("respuesta no es JSON válido")
+
+        # Criterio 2: Campos requeridos (40%)
+        has_fields = False
+
+        if required_fields:
+            if parsed is not None:
+                found = [f for f in required_fields if f in parsed]
+                ratio = len(found) / len(required_fields)
+                has_fields = ratio == 1.0
+                score += 0.40 * ratio
+                if ratio < 1.0:
+                    missing = [f for f in required_fields if f not in parsed]
+                    reasons.append(f"campos faltantes: {missing}")
+            else:
+                reasons.append("no se pueden verificar campos — respuesta no es JSON")
+        else:
+            # Sin campos requeridos: este criterio se cumple automáticamente
+            has_fields = True
+            score += 0.40
+
+        # Criterio 3: Latencia (25%) 
+        latency_score = max(0.0, 1.0 - (latency_ms / max_acceptable_latency_ms))
+        score += 0.25 * latency_score
+
+        if latency_ms > max_acceptable_latency_ms * 0.8:
+            reasons.append(f"latencia alta: {latency_ms:.0f}ms")
+
+        # Confianza reportada por el LLM (0-20%)
+        confidence_indicator: Optional[float] = None
+
+        if parsed and "confidence" in parsed:
+            try:
+                conf = float(parsed["confidence"])
+                if 0.0 <= conf <= 1.0:
+                    confidence_indicator = conf
+                    # No más del 20% de influencia
+                    score = score * 0.80 + conf * 0.20
+            except (TypeError, ValueError):
+                pass
+
+        return EvaluationResult(
+            score=min(1.0, max(0.0, score)),
+            is_valid_json=is_json,
+            has_required_fields=has_fields,
+            latency_ms=latency_ms,
+            confidence_indicator=confidence_indicator,
+            reasons=reasons,
+        )
+
+    def evaluate_best(
+        self,
+        responses: list[tuple[str, str, float]],
+        required_fields: list[str],
+    ) -> tuple[int, list[EvaluationResult]]:
+        """
+        Evalúa múltiples respuestas y retorna el índice del mejor.
+
+        Args:
+            responses:       Lista de (llm_name, content, latency_ms).
+            required_fields: Campos requeridos para todas las respuestas.
+
+        Returns:
+            (índice_del_mejor, lista_de_evaluaciones)
+
+        Example:
+            >>> best_idx, evals = evaluator.evaluate_best(
+            ...     [("ollama", '{"big_o":"O(n)"}', 200),
+            ...      ("claude", '{"big_o":"O(n)","omega":"Omega(1)"}', 800)],
+            ...     required_fields=["big_o", "omega"]
+            ... )
+        """
+        evaluations = [
+            self.evaluate(content, required_fields, latency)
+            for _, content, latency in responses
+        ]
+
+        best_idx = max(range(len(evaluations)), key=lambda i: evaluations[i].score)
+        return best_idx, evaluations

--- a/backend/app/infrastructure/llm/llm_factory.py
+++ b/backend/app/infrastructure/llm/llm_factory.py
@@ -11,6 +11,7 @@ from app.infrastructure.llm.base_llm import BaseLLM
 from app.infrastructure.llm.claude_adapter import ClaudeAdapter
 from app.infrastructure.llm.gemini_adapter import GeminiAdapter
 from app.infrastructure.llm.ollama_adapter import OllamaAdapter
+from app.infrastructure.llm.llm_router import LLMRouter
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -24,20 +25,20 @@ class LLMFactory:
     def create(llm_type: Optional[LLMType] = None) -> BaseLLM:
         """
         Crea instancia de LLM.
- 
+
         Args:
             llm_type: "claude", "gemini" u "ollama".
                      Si es None, usa PRIMARY_LLM de settings.
- 
+
         Returns:
             BaseLLM: Instancia del LLM correspondiente
- 
+
         Raises:
             ValueError: Si llm_type no es un tipo soportado
         """
         if llm_type is None:
             llm_type = settings.PRIMARY_LLM
- 
+
         if llm_type == "claude":
             if not settings.ANTHROPIC_API_KEY:
                 raise ValueError(
@@ -45,7 +46,7 @@ class LLMFactory:
                     "Añadir a .env para usar Claude."
                 )
             return ClaudeAdapter()
- 
+
         elif llm_type == "gemini":
             if not settings.GOOGLE_API_KEY:
                 raise ValueError(
@@ -63,7 +64,7 @@ class LLMFactory:
                 f"LLM type no soportado: '{llm_type}'. "
                 f"Valores válidos: 'claude', 'gemini', 'ollama'"
             )
- 
+
     @staticmethod
     def create_primary() -> BaseLLM:
         """Crea LLM primario según settings.PRIMARY_LLM."""
@@ -72,12 +73,12 @@ class LLMFactory:
         except Exception as e:
             logger.error(f"No se pudo crear LLM primario '{settings.PRIMARY_LLM}': {e}")
             raise
- 
+
     @staticmethod
     def create_fallback() -> Optional[BaseLLM]:
         """
         Crea LLM de fallback según settings.FALLBACK_LLM.
- 
+
         Retorna None si no está configurado, en lugar de lanzar excepción.
         """
         try:
@@ -87,18 +88,18 @@ class LLMFactory:
                 f"LLM fallback '{settings.FALLBACK_LLM}' no disponible: {e}"
             )
             return None
- 
+
     @staticmethod
     def create_validation_chain() -> List[BaseLLM]:
         """
         Crea la cadena completa de LLMs para validación cruzada.
- 
+
         El orden refleja el flujo: primario → fallback → adicionales.
         Solo incluye LLMs que están configurados.
- 
+
         Returns:
             Lista de LLMs en orden de prioridad
- 
+
         Example:
             >>> chain = LLMFactory.create_validation_chain()
             >>> # [OllamaAdapter, GeminiAdapter, ClaudeAdapter]
@@ -106,13 +107,13 @@ class LLMFactory:
             ...     result = await llm.generate_json(prompt)
         """
         chain = []
- 
+
         # Primario
         try:
             chain.append(LLMFactory.create_primary())
         except Exception as e:
             logger.warning(f"LLM primario no disponible: {e}")
- 
+
         # Fallback (solo si es diferente del primario)
         if settings.FALLBACK_LLM != settings.PRIMARY_LLM:
             try:
@@ -194,3 +195,59 @@ class LLMFactory:
         status["fallback"] = settings.FALLBACK_LLM
 
         return status
+    
+    @staticmethod
+    def create_router(
+        min_acceptable_score: float = 0.6,
+        timeout_seconds: float = 30.0,
+        max_retries: int = 3,
+    ) -> "LLMRouter":
+        """
+        Crea un LLMRouter con primario y fallback según settings.
+
+        El router encapsula circuit breaker, evaluación de calidad
+        y retry automático. Es el punto de entrada recomendado
+        para cualquier uso de LLMs que requiera resiliencia.
+
+        Args:
+            min_acceptable_score: Score mínimo para aceptar respuesta
+                                  del primario (0.0-1.0).
+            timeout_seconds:      Timeout por llamada individual.
+            max_retries:          Reintentos ante fallos de red.
+
+        Returns:
+            LLMRouter configurado con primario y fallback de settings.
+
+        Example:
+            >>> router = LLMFactory.create_router()
+            >>> routed = await router.route(
+            ...     prompt="...",
+            ...     required_fields=["big_o", "omega"],
+            ... )
+            >>> print(routed.llm_used)
+        """
+        from app.infrastructure.llm.llm_router import LLMRouter
+
+        primary = LLMFactory.create_primary()
+        fallback = LLMFactory.create_fallback()
+
+        return LLMRouter(
+            primary=primary,
+            fallback=fallback,
+            min_acceptable_score=min_acceptable_score,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+        )
+
+    @staticmethod
+    async def check_router_health() -> dict:
+        """
+        Verifica el estado de salud del router y sus circuit breakers.
+
+        Útil para el endpoint /health y para Prometheus.
+
+        Returns:
+            Dict con estado de cada LLM y sus circuit breakers.
+        """
+        router = LLMFactory.create_router()
+        return router.get_status()

--- a/backend/app/infrastructure/llm/llm_router.py
+++ b/backend/app/infrastructure/llm/llm_router.py
@@ -1,0 +1,317 @@
+"""
+LLMRouter — Routing inteligente entre LLMs con circuit breaker y retry.
+
+Flujo de decisión:
+    1. ¿Está el primario disponible? (circuit breaker CLOSED o HALF_OPEN)
+    2. Llamar al primario con timeout y retry (tenacity)
+    3. Evaluar respuesta — si score < min_acceptable_score → intentar fallback
+    4. Si fallback también falla → propagar excepción
+
+Integración con el sistema existente:
+    - Los adaptadores (Claude, Gemini, Ollama) NO cambian
+    - LLMFactory.create_router() es el punto de entrada recomendado
+    - LLMValidationStep usará el router cuando se implemente
+
+Métricas expuestas:
+    - router.get_circuit_breaker_metrics() → para Prometheus
+    - RoutedResponse.evaluation.to_dict() → para logging estructurado
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from app.infrastructure.llm.base_llm import BaseLLM, LLMResponse
+from app.infrastructure.llm.llm_circuit_breaker import CircuitBreaker, CircuitBreakerMetrics
+from app.infrastructure.llm.llm_evaluator import EvaluationResult, LLMEvaluator
+from app.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+@dataclass
+class RoutedResponse:
+    """
+    Respuesta del router con metadata de routing.
+
+    Incluye qué LLM se usó, si se activó el fallback y
+    el score de calidad de la respuesta.
+    """
+    response: LLMResponse
+    llm_used: str
+    evaluation: EvaluationResult
+    fallback_used: bool = False
+    attempts: int = 1
+
+    def to_dict(self) -> dict:
+        return {
+            "llm_used":     self.llm_used,
+            "fallback_used": self.fallback_used,
+            "attempts":     self.attempts,
+            "evaluation":   self.evaluation.to_dict(),
+            "tokens_used":  self.response.tokens_used,
+        }
+
+class LLMRouter:
+    """
+    Router inteligente que selecciona el LLM óptimo por llamada.
+
+    Se usa en lugar de llamar directamente a un adaptador LLM.
+    Encapsula circuit breaker, evaluación de calidad y retry.
+
+    Args:
+        primary:               LLM principal (normalmente Ollama).
+        fallback:              LLM de respaldo (normalmente Claude o Gemini).
+        min_acceptable_score:  Score mínimo para aceptar respuesta del primario
+                               sin intentar el fallback.
+        timeout_seconds:       Timeout por llamada individual (sin contar retries).
+        max_retries:           Número de reintentos ante fallos de red/timeout.
+
+    Example:
+        >>> router = LLMFactory.create_router()
+        >>> routed = await router.route(
+        ...     prompt="Analiza esta complejidad...",
+        ...     required_fields=["big_o", "omega", "reasoning"],
+        ... )
+        >>> print(routed.llm_used)
+        >>> print(routed.evaluation.score)
+    """
+
+    def __init__(
+        self,
+        primary: BaseLLM,
+        fallback: Optional[BaseLLM] = None,
+        min_acceptable_score: float = 0.6,
+        timeout_seconds: float = 30.0,
+        max_retries: int = 3,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+        self._evaluator = LLMEvaluator()
+        self._min_score = min_acceptable_score
+        self._timeout = timeout_seconds
+        self._max_retries = max_retries
+
+        # Un CircuitBreaker por adaptador
+        self._breakers: dict[str, CircuitBreaker] = {
+            self._llm_name(primary): CircuitBreaker(
+                name=self._llm_name(primary),
+                failure_threshold=5,
+                recovery_timeout=60.0,
+            ),
+        }
+        if fallback:
+            self._breakers[self._llm_name(fallback)] = CircuitBreaker(
+                name=self._llm_name(fallback),
+                failure_threshold=5,
+                recovery_timeout=120.0,
+            )
+
+    #  Punto de entrada principal                                         
+    async def route(
+        self,
+        prompt: str,
+        required_fields: list[str] = None,
+        system_prompt: Optional[str] = None,
+    ) -> RoutedResponse:
+        """
+        Enruta la llamada al mejor LLM disponible.
+
+        Args:
+            prompt:          Prompt a enviar al LLM.
+            required_fields: Campos JSON que deben estar en la respuesta.
+                             Vacío = solo validar latencia y JSON.
+            system_prompt:   System prompt opcional.
+
+        Returns:
+            RoutedResponse con la respuesta y metadata de routing.
+
+        Raises:
+            RuntimeError: Si todos los LLMs fallan o tienen circuit breakers abiertos.
+        """
+        required_fields = required_fields or []
+        primary_name = self._llm_name(self._primary)
+        primary_cb = self._breakers[primary_name]
+
+        # ── Intentar primario ────────────────────────────────────────────
+        if not primary_cb.is_open:
+            try:
+                response, latency, attempts = await self._call_with_retry(
+                    self._primary, prompt, system_prompt
+                )
+                primary_cb.record_success()
+
+                evaluation = self._evaluator.evaluate(
+                    response.content, required_fields, latency
+                )
+
+                if evaluation.score >= self._min_score:
+                    logger.debug(
+                        f"LLMRouter: {primary_name} aceptado "
+                        f"(score={evaluation.score:.2f})"
+                    )
+                    return RoutedResponse(
+                        response=response,
+                        llm_used=primary_name,
+                        evaluation=evaluation,
+                        fallback_used=False,
+                        attempts=attempts,
+                    )
+
+                logger.info(
+                    f"LLMRouter: {primary_name} score bajo ({evaluation.score:.2f}), "
+                    f"razones: {evaluation.reasons} — intentando fallback"
+                )
+
+            except Exception as exc:
+                primary_cb.record_failure()
+                logger.warning(
+                    f"LLMRouter: {primary_name} falló ({type(exc).__name__}: {exc}), "
+                    f"circuit breaker: {primary_cb.state.value}"
+                )
+        else:
+            logger.info(
+                f"LLMRouter: circuit breaker abierto para {primary_name} "
+                f"— usando fallback directamente"
+            )
+
+        # ── Intentar fallback ────────────────────────────────────────────
+        if self._fallback:
+            fallback_name = self._llm_name(self._fallback)
+            fallback_cb = self._breakers.get(fallback_name)
+
+            if fallback_cb and not fallback_cb.is_open:
+                try:
+                    response, latency, attempts = await self._call_with_retry(
+                        self._fallback, prompt, system_prompt
+                    )
+                    fallback_cb.record_success()
+
+                    evaluation = self._evaluator.evaluate(
+                        response.content, required_fields, latency
+                    )
+
+                    logger.info(
+                        f"LLMRouter: fallback {fallback_name} usado "
+                        f"(score={evaluation.score:.2f})"
+                    )
+                    return RoutedResponse(
+                        response=response,
+                        llm_used=fallback_name,
+                        evaluation=evaluation,
+                        fallback_used=True,
+                        attempts=attempts,
+                    )
+
+                except Exception as exc:
+                    if fallback_cb:
+                        fallback_cb.record_failure()
+                    logger.error(
+                        f"LLMRouter: fallback {fallback_name} también falló — {exc}"
+                    )
+
+        raise RuntimeError(
+            f"Todos los LLMs fallaron o tienen circuit breakers abiertos. "
+            f"Estados: {self._format_breaker_states()}"
+        )
+
+    async def route_json(
+        self,
+        prompt: str,
+        required_fields: list[str] = None,
+        system_prompt: Optional[str] = None,
+    ) -> dict:
+        """
+        Versión conveniente que retorna el JSON parseado directamente.
+
+        Llama a route() y parsea el contenido de la respuesta.
+        """
+        import json
+
+        routed = await self.route(prompt, required_fields, system_prompt)
+        content = routed.response.content.strip()
+
+        # Limpiar markdown code fences si están presentes
+        for fence in ("```json", "```"):
+            if content.startswith(fence):
+                content = content[len(fence):]
+        if content.endswith("```"):
+            content = content[:-3]
+        content = content.strip()
+
+        return json.loads(content)
+
+    #  Métricas                                                           
+    def get_circuit_breaker_metrics(self) -> list[CircuitBreakerMetrics]:
+        """
+        Retorna el estado de todos los circuit breakers.
+
+        Usar para exponer a Prometheus o para logging de health check.
+        """
+        return [cb.get_metrics() for cb in self._breakers.values()]
+
+    def get_status(self) -> dict:
+        """Resumen del estado del router para el endpoint /health."""
+        return {
+            "primary":  self._llm_name(self._primary),
+            "fallback": self._llm_name(self._fallback) if self._fallback else None,
+            "circuit_breakers": [
+                m.to_dict() for m in self.get_circuit_breaker_metrics()
+            ],
+        }
+
+    #  Helpers privados                                                   
+    async def _call_with_retry(
+        self,
+        llm: BaseLLM,
+        prompt: str,
+        system_prompt: Optional[str],
+    ) -> tuple[LLMResponse, float, int]:
+        """
+        Llama al LLM con timeout y retry exponencial.
+
+        Retorna (response, latency_ms, attempts).
+        """
+        attempts = 0
+
+        @retry(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            retry=retry_if_exception_type((TimeoutError, ConnectionError, OSError)),
+            reraise=True,
+        )
+        async def _attempt() -> tuple[LLMResponse, float]:
+            nonlocal attempts
+            attempts += 1
+            start = time.perf_counter()
+            response = await asyncio.wait_for(
+                llm.generate(prompt, system_prompt=system_prompt),
+                timeout=self._timeout,
+            )
+            latency = (time.perf_counter() - start) * 1000
+            return response, latency
+
+        response, latency = await _attempt()
+        return response, latency, attempts
+
+    @staticmethod
+    def _llm_name(llm: Optional[BaseLLM]) -> str:
+        """Nombre corto del adaptador para logs y métricas."""
+        if llm is None:
+            return "none"
+        return type(llm).__name__.replace("Adapter", "").lower()
+
+    def _format_breaker_states(self) -> str:
+        return ", ".join(
+            f"{name}={cb.state.value}"
+            for name, cb in self._breakers.items()
+        )


### PR DESCRIPTION
Añade llm_circuit_breaker.py: implementación de circuit breaker para proteger y desacoplar llamadas a LLMs (estados, umbrales, backoff/reintentos).
Añade llm_evaluator.py: componente para evaluar, normalizar y validar respuestas de LLMs, y registrar métricas/errores.
Añade llm_router.py: router para seleccionar el LLM adecuado según política (salud, latencia, coste).
Modifica llm_factory.py: integra el circuit breaker y el router en la creación/registro de instancias LLM; expone configuración para umbrales y políticas.