### PR TITLE
feat(mongo,ci): agregar versionado en modelos Mongo y pipeline CI/CD

### DIFF
--- a/backend/.github/workflows/ci.yml
+++ b/backend/.github/workflows/ci.yml
@@ -1,0 +1,210 @@
+# Pipeline de CI para Complexity Analyzer Backend
+#
+# Triggers:
+#   - Push a main o develop
+#   - Pull Request hacia main
+#
+# Jobs:
+#   1. test    — lint + tipos + smoke + unit + regression
+#   2. build   — Docker image (solo en main)
+#   3. quality — coverage report
+# ============================================================
+
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "backend/**"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  # Job 1: Tests
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    services:
+      mongodb:
+        image: mongo:7.0
+        ports: ["27017:27017"]
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ping:1})'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      APP_ENV: testing
+      DATABASE_TYPE: mongodb
+      MONGODB_URL: mongodb://localhost:27017
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+      IDS_ENABLED: "false"
+      ENABLE_PROMETHEUS: "false"
+      CELERY_ENABLED: "false"
+      # LLM keys vacíos en CI — los tests usan mocks
+      ANTHROPIC_API_KEY: ""
+      GOOGLE_API_KEY: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: backend/requirements*.txt
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      # Lint 
+      - name: Lint with ruff
+        run: ruff check app/ tests/ --output-format=github
+        continue-on-error: false
+
+      - name: Format check with black
+        run: black --check app/ tests/
+
+      # Type check 
+      - name: Type check with mypy
+        run: mypy app/ --ignore-missing-imports --no-error-summary
+        continue-on-error: true  # Warnings, no bloquea
+
+      # Smoke tests (rápidos, verifican arranque)
+      - name: Smoke tests
+        run: |
+          pytest tests/smoke/ -m smoke -x \
+            --timeout=30 \
+            --tb=short \
+            -q
+
+      # Unit tests 
+      - name: Unit tests
+        run: |
+          pytest tests/unit/ -m unit \
+            --timeout=60 \
+            --tb=short \
+            --cov=app \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing \
+            -q
+
+      # Regression tests (verifican corrección semántica)
+      - name: Regression tests
+        run: |
+          pytest tests/regression/ -m regression \
+            --timeout=120 \
+            --tb=short \
+            -q
+
+      # Contract tests (verifican schemas de API)
+      - name: Contract tests
+        run: |
+          pytest tests/contract/ -m contract \
+            --timeout=60 \
+            --tb=short \
+            -q
+
+      # Upload coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.11'
+        with:
+          file: backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Job 2: Docker build (solo en push a main)
+  build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: false
+          tags: complexity-analyzer-api:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test Docker image
+        run: |
+          docker run -d \
+            --name test-api \
+            -p 8001:8000 \
+            -e APP_ENV=testing \
+            -e DATABASE_TYPE=mongodb \
+            -e MONGODB_URL=mongodb://localhost:27017 \
+            -e IDS_ENABLED=false \
+            -e CELERY_ENABLED=false \
+            complexity-analyzer-api:${{ github.sha }}
+          
+          # Esperar a que arranque
+          for i in {1..10}; do
+            if curl -sf http://localhost:8001/api/v1/health > /dev/null 2>&1; then
+              echo "API health check passed"
+              break
+            fi
+            echo "Waiting... ($i/10)"
+            sleep 3
+          done
+          
+          curl -f http://localhost:8001/api/v1/health || exit 1
+          docker stop test-api
+
+  # Job 3: Quality gate
+  quality:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Tests fallaron — quality gate bloqueado"
+            exit 1
+          fi
+          echo "Tests pasaron — quality gate OK"

--- a/backend/app/infrastructure/database/models/mongo/__init__.py
+++ b/backend/app/infrastructure/database/models/mongo/__init__.py
@@ -1,9 +1,11 @@
 from app.infrastructure.database.models.mongo.algorithm import Algorithm
 from app.infrastructure.database.models.mongo.analysis_result import AnalysisResult
 from app.infrastructure.database.models.mongo.pattern_detection import PatternDetection
+from app.infrastructure.database.models.mongo.versioning import VersioningMixin
 
 __all__ = [
     "Algorithm",
     "AnalysisResult",
     "PatternDetection",
+    "VersioningMixin"
 ]

--- a/backend/app/infrastructure/database/models/mongo/analysis_result.py
+++ b/backend/app/infrastructure/database/models/mongo/analysis_result.py
@@ -1,5 +1,8 @@
+"""
+Modelo MongoDB para Resultados de Análisis.
+"""
 from datetime import datetime
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any
 from beanie import Document, Link
 from pydantic import Field
 
@@ -27,6 +30,28 @@ class AnalysisResult(Document):
     # Metadata
     analysis_time: float = Field(..., description="Tiempo de análisis en segundos")
     analyzer_version: str = Field(default="1.0.0")
+
+    # Versionado del sistema 
+    system_version: str = Field(
+        default="1.0.0",
+        description="Versión semver del sistema que generó este análisis"
+    )
+    pipeline_version: str = Field(
+        default="2.0",
+        description="Versión del pipeline (2.0 = pipeline formal con pasos)"
+    )
+    analysis_schema_version: str = Field(
+        default="1.0",
+        description="Versión del schema de resultado — bump si cambia la estructura"
+    )
+    llm_used: Optional[str] = Field(
+        default=None,
+        description="LLM que participó en el análisis (None = solo análisis estático)"
+    )
+    config_snapshot: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Feature flags y configuración activa al momento del análisis"
+    )
 
     # Timestamps
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/infrastructure/database/models/mongo/versioning.py
+++ b/backend/app/infrastructure/database/models/mongo/versioning.py
@@ -1,0 +1,93 @@
+"""
+VersioningMixin — Campos de versionado reutilizables para modelos MongoDB.
+
+En lugar de duplicar los campos en cada modelo, heredar este mixin.
+
+Uso:
+    from app.infrastructure.database.models.mongo.versioning import VersioningMixin
+    from beanie import Document
+    from pydantic import Field
+
+    class AnalysisResult(Document, VersioningMixin):
+        # ... campos existentes ...
+        pass
+
+O como campos directos si el modelo no puede heredar del mixin:
+    system_version: str = Field(default="1.0.0")
+    pipeline_version: str = Field(default="2.0")
+    analysis_schema_version: str = Field(default="1.0")
+    llm_used: Optional[str] = Field(default=None)
+    config_snapshot: dict = Field(default_factory=dict)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+class VersioningMixin(BaseModel):
+    """
+    Mixin con campos de versionado para modelos MongoDB.
+
+    Permite reproducir exactamente qué configuración generó
+    un resultado específico y comparar entre versiones del sistema.
+
+    Todos los campos tienen defaults seguros para que documentos
+    históricos sin estos campos sigan siendo válidos.
+    """
+
+    system_version: str = Field(
+        default="1.0.0",
+        description="Versión semver del sistema (app.core.config.APP_VERSION)"
+    )
+    pipeline_version: str = Field(
+        default="2.0",
+        description="Versión del pipeline de análisis"
+    )
+    analysis_schema_version: str = Field(
+        default="1.0",
+        description="Versión del schema de resultado"
+    )
+    llm_used: Optional[str] = Field(
+        default=None,
+        description="LLM que participó en el análisis (None = sin LLM)"
+    )
+    config_snapshot: dict = Field(
+        default_factory=dict,
+        description="Snapshot de feature flags activos al momento del análisis"
+    )
+
+    @classmethod
+    def build_config_snapshot(cls, pipeline_steps: list[str] = None) -> dict:
+        """
+        Construye el snapshot de configuración desde settings actuales.
+
+        Llamar antes de guardar un documento para capturar la configuración
+        que produjo ese resultado específico.
+
+        Args:
+            pipeline_steps: Lista de nombres de pasos activos en el pipeline.
+
+        Returns:
+            Dict con la configuración relevante del momento.
+
+        Example:
+            result_doc.config_snapshot = VersioningMixin.build_config_snapshot(
+                pipeline_steps=["parse", "complexity", "patterns", "structures"]
+            )
+        """
+        try:
+            from app.core.config import settings
+            return {
+                "primary_llm":            settings.PRIMARY_LLM,
+                "fallback_llm":           settings.FALLBACK_LLM,
+                "multiagent_enabled":     settings.ENABLE_MULTIAGENT_SYSTEM,
+                "llm_validation_enabled": getattr(
+                    settings, "LLM_VALIDATION_ENABLED", False
+                ),
+                "pipeline_steps":         pipeline_steps or [],
+                "cache_ttl_analysis":     settings.CACHE_TTL_ANALYSIS,
+            }
+        except Exception:
+            return {"pipeline_steps": pipeline_steps or []}


### PR DESCRIPTION
backend/app/infrastructure/database/models/mongo/init.py: exporta VersioningMixin y centraliza modelos mongo.
backend/app/infrastructure/database/models/mongo/versioning.py: nuevo VersioningMixin con campos de versionado y build_config_snapshot.
backend/app/infrastructure/database/models/mongo/analysis_result.py: incorpora campos de versionado (system_version, pipeline_version, analysis_schema_version, llm_used, config_snapshot) y mantiene analyzer_version.
backend/.github/workflows/ci.yml: workflow de GitHub Actions para tests, build (solo en main) y quality gate (coverage/codecove)